### PR TITLE
feat: use pebble as rock entrypoint

### DIFF
--- a/0.110.0/rockcraft.yaml
+++ b/0.110.0/rockcraft.yaml
@@ -15,8 +15,6 @@ services:
     summary: "Entry point for opentelemetry-collector oci-image"
     startup: enabled
     command: "/usr/bin/otelcol [ --config /etc/otelcol/config.yaml ]"
-entrypoint-service: otelcol
-
 run-user: _daemon_
 parts:
   opentelemetry-collector:
@@ -38,8 +36,8 @@ parts:
       opt/otelcol/config.yaml: etc/otelcol/config.yaml
 
     permissions:
-        # _daemon_ user has UID/GID = 584792
-        # Ref: https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml/#run-user
+      # _daemon_ user has UID/GID = 584792
+      # Ref: https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml/#run-user
       - path: etc/otelcol/config.yaml
         owner: 584792
         group: 584792

--- a/0.117.0/rockcraft.yaml
+++ b/0.117.0/rockcraft.yaml
@@ -15,7 +15,6 @@ services:
     summary: "Entry point for opentelemetry-collector oci-image"
     startup: enabled
     command: "/usr/bin/otelcol [ --config /etc/otelcol/config.yaml ]"
-entrypoint-service: otelcol
 run-user: _daemon_
 parts:
   opentelemetry-collector:

--- a/0.118.0/rockcraft.yaml
+++ b/0.118.0/rockcraft.yaml
@@ -15,7 +15,6 @@ services:
     summary: "Entry point for opentelemetry-collector oci-image"
     startup: enabled
     command: "/usr/bin/otelcol [ --config /etc/otelcol/config.yaml ]"
-entrypoint-service: otelcol
 run-user: _daemon_
 parts:
   opentelemetry-collector:


### PR DESCRIPTION
## Issue
The OpenTelemetry rock should have Pebble as its entrypoint, as noted in the OCI Factory onboarding PR: https://github.com/canonical/oci-factory/pull/345


## Solution
Delete the line specifying a different entrypoint and verify tests are passing.
