### PR TITLE
feat: add integration tests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,5 +12,5 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v1
     secrets: inherit

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v1
     secrets: inherit
     with:
       rock-name: opentelemetry-collector

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v1
     secrets: inherit
     with:
       rock-name: opentelemetry-collector

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-update.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v1
     with:
       rock-name: opentelemetry-collector
       source-repo: open-telemetry/opentelemetry-collector-releases

--- a/justfile
+++ b/justfile
@@ -2,7 +2,8 @@ set quiet # Recipes are silent by default
 set export # Just variables are exported to environment variables
 
 rock_name := `echo ${PWD##*/} | sed 's/-rock//'`
-latest_version := `find . -maxdepth 1 -type d | sort -V | tail -n1 | sed 's@./@@'`
+# To find the latest version, get the "last" folder that starts with a number
+latest_version := `find . -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -n1 | sed 's@./@@'`
 
 [private]
 default:
@@ -14,7 +15,7 @@ push-to-registry version:
   echo "Pushing $rock_name $version to local registry"
   rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
     "oci-archive:${version}/${rock_name}_${version}_amd64.rock" \
-    "docker://localhost:32000/${rock_name}-dev:${version}"
+    "docker://localhost:32000/${rock_name}-dev:${version}" >/dev/null
 
 # Pack a rock of a specific version
 pack version:
@@ -30,6 +31,42 @@ clean version:
 run version=latest_version: (push-to-registry version)
   kgoss edit -i localhost:32000/${rock_name}-dev:${version}
 
+# Run all the tests
+[group("test")]
+test version=latest_version: (push-to-registry version) \
+  (test-isolation version) \
+  (test-integration version)
+
 # Test the rock with `kgoss`
-test version=latest_version: (push-to-registry version)
+[group("test")]
+test-isolation version=latest_version: (push-to-registry version)
   GOSS_OPTS="--retry-timeout 60s" kgoss run -i localhost:32000/${rock_name}-dev:${version}
+
+# Test the rock integration with other workloads
+[group("test")]
+test-integration version=latest_version: (push-to-registry version)
+  #!/usr/bin/env bash
+  # For all the subfolder in tests/
+  for test_folder in $(find tests -mindepth 1 -maxdepth 1 -type d | sed 's@tests/@@'); do
+    # Create a namespace for the tests to run in
+    namespace="test-${rock_name}-rock-${test_folder//_/-}"
+    echo "+ Preparing the testing environment"
+    kubectl delete all --all -n "$namespace" >/dev/null
+    kubectl delete namespace "$namespace" >/dev/null
+    kubectl create namespace "$namespace"
+    # For each  '.yaml' file (excluding 'goss.yaml')
+    for manifest in $(find tests/${test_folder} -type f -name '*.yaml' | grep -v 'goss.yaml'); do
+      kubectl apply -f "$manifest" -n "$namespace"  # deploy it in the test namespace
+    done
+    sleep 15 # Wait for the pods to settle and otel-collector to remote-write
+    NAMESPACE="$namespace" goss \
+      --gossfile "tests/${test_folder}/goss.yaml" \
+      --log-level debug \
+      validate \
+      --retry-timeout=120s \
+      --sleep=5s
+    # Cleanup
+    echo "+ Cleaning up the testing environment"
+    kubectl delete all --all -n "$namespace"
+    kubectl delete namespace "$namespace"
+  done

--- a/tests/prometheus_integration/goss.yaml
+++ b/tests/prometheus_integration/goss.yaml
@@ -1,0 +1,20 @@
+command:
+  remote-write:
+    exit-status: 0
+    exec: |
+      echo "Namespace: {{.Env.NAMESPACE}}"
+      # Get Prometheus pod
+      PROMETHEUS_IP="$(kubectl get pod -n {{.Env.NAMESPACE}} -l app="prometheus" \
+        -o jsonpath='{.items[*].status.podIP}')"
+      if [ -z "$PROMETHEUS_IP" ]; then
+        echo "Prometheus pod IP not found, maybe the pod isn't ready yet"
+        exit 1
+      fi
+      echo "Prometheus IP: $PROMETHEUS_IP"
+      # Check there is a `job` label with value `otel-collector`
+      LABELS="$(curl -s "${PROMETHEUS_IP}:9090/api/v1/label/job/values")"
+      echo "Prometheus 'job' label values: $LABELS"
+      if ! echo "$LABELS" | grep -q "otel-collector"; then
+        echo "'job=otel-collector' label not found"
+        exit 2
+      fi

--- a/tests/prometheus_integration/otel-collector.yaml
+++ b/tests/prometheus_integration/otel-collector.yaml
@@ -1,0 +1,84 @@
+--- # OpenTelemetry Collector config
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otelcol-config
+data:
+  config.yaml: |
+    # otel config goes here
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: 'otel-collector'
+            scrape_interval: 10s
+            static_configs:
+            - targets: ['0.0.0.0:8888']
+
+    exporters:
+      debug:
+        verbosity: detailed
+      prometheus:
+        endpoint: ":8889"
+      prometheusremotewrite:
+        endpoint: "http://prometheus.test-opentelemetry-collector-rock-prometheus-integration.svc.cluster.local:9090/api/v1/write"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug, prometheus, prometheusremotewrite]
+      extensions: [health_check]
+      telemetry:
+        metrics:
+          level: basic # Set to 'normal' or 'detailed' for more metrics
+--- # OpenTelemetry Collector deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-collector-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opentelemetry-collector-dev
+  template:
+    metadata:
+      labels:
+        app: opentelemetry-collector-dev
+    spec:
+      containers:
+        - name: opentelemetry-collector-dev
+          image: localhost:32000/opentelemetry-collector-dev:0.118.0
+          ports:
+            - containerPort: 55678 # workload ports, add more if needed
+            - containerPort: 13133 # health endpoint
+            - containerPort: 8888 # metrics
+          volumeMounts:
+            - name: otelcol-config-volume
+              mountPath: /etc/otelcol/config.yaml # Change this to the desired mount path
+              subPath: config.yaml  # This specifies the file name in the ConfigMap
+      volumes:
+        - name: otelcol-config-volume
+          configMap:
+            name: otelcol-config
+--- # OpenTelemetry Collector Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-collector-dev
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8888
+      name: prometheus-receiver
+    - port: 8889
+      name: metrics-endpoint
+    - port: 13133
+      name: health-check
+  selector:
+    app: opentelemetry-collector-dev

--- a/tests/prometheus_integration/prometheus.yaml
+++ b/tests/prometheus_integration/prometheus.yaml
@@ -1,0 +1,55 @@
+--- # Prometheus config
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    # prometheus config goes here
+    global:
+      scrape_interval: 15s  # Default scrape interval
+
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090']  # Adjust as necessary
+--- # Prometheus Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: ubuntu/prometheus:2.53-24.04
+          args: ["--args", "prometheus", "--web.enable-remote-write-receiver"]
+          ports:
+            - containerPort: 9090 # Prometheus port
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-config
+--- # Prometheus Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+  selector:
+    app: prometheus


### PR DESCRIPTION
## Issue
Supersedes https://github.com/canonical/opentelemetry-collector-rock/pull/9

This PR adds “integration tests” machinery for otel-collector, to make sure otel-collector is able to remote write to Prometheus.

This is useful because we build otel-collector with a subset of plugins, so we want to make sure we don't break anything.

