### PR TITLE
Version mismatch

### DIFF
--- a/0.123.1/rockcraft.yaml
+++ b/0.123.1/rockcraft.yaml
@@ -29,15 +29,8 @@ parts:
       - CGO_ENABLED: "0"
       - GOOS: linux
     override-build: |
-      get_builder_latest_version() {
-        set +o pipefail
-        local version=$(git ls-remote --tags --sort=-v:refname https://github.com/open-telemetry/opentelemetry-collector/ | head -n 1 | awk '{print $2}' | sed -E 's|refs/tags/||;s|\^\{\}||')
-        set -o pipefail
-        echo "$version"
-      }
-      BUILDER_VERSION=$(get_builder_latest_version)
       # Create the binary
-      go install go.opentelemetry.io/collector/cmd/builder@${BUILDER_VERSION}
+      go install go.opentelemetry.io/collector/cmd/builder@v0.123.0
       /root/go/bin/builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol ${CRAFT_PART_INSTALL}/opt/otelcol/otelcol
     organize:

--- a/0.123.1/rockcraft.yaml
+++ b/0.123.1/rockcraft.yaml
@@ -31,6 +31,8 @@ parts:
       - GOOS: linux
     stage:
       - bin/builder
+    prime:
+      - "-*"
   opentelemetry-collector:
     after:
       - ocb

--- a/0.123.1/rockcraft.yaml
+++ b/0.123.1/rockcraft.yaml
@@ -23,13 +23,21 @@ parts:
     build-snaps:
       - yq/v4/stable
       - go/1.23/stable
+    build-packages:
+      - git
     build-environment:
       - CGO_ENABLED: "0"
       - GOOS: linux
     override-build: |
-      VERSION=v$(yq '.version' rockcraft.yaml)
+      get_latest_version() {
+        set +o pipefail
+        local version=$(git ls-remote --tags --sort=-v:refname https://github.com/open-telemetry/opentelemetry-collector/ | head -n 1 | awk '{print $2}' | sed -E 's|refs/tags/||;s|\^\{\}||')
+        set -o pipefail
+        echo "$version"
+      }
+      BUILDER_VERSION=$(get_latest_version)
       # Create the binary
-      go install go.opentelemetry.io/collector/cmd/builder@$VERSION
+      go install go.opentelemetry.io/collector/cmd/builder@${BUILDER_VERSION}
       /root/go/bin/builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol ${CRAFT_PART_INSTALL}/opt/otelcol/otelcol
     organize:
@@ -41,7 +49,6 @@ parts:
         owner: 584792
         group: 584792
         mode: "500"
-    source-tag: v0.123.1
   default-config:
     plugin: dump
     source: .

--- a/0.123.1/rockcraft.yaml
+++ b/0.123.1/rockcraft.yaml
@@ -29,13 +29,13 @@ parts:
       - CGO_ENABLED: "0"
       - GOOS: linux
     override-build: |
-      get_latest_version() {
+      get_builder_latest_version() {
         set +o pipefail
         local version=$(git ls-remote --tags --sort=-v:refname https://github.com/open-telemetry/opentelemetry-collector/ | head -n 1 | awk '{print $2}' | sed -E 's|refs/tags/||;s|\^\{\}||')
         set -o pipefail
         echo "$version"
       }
-      BUILDER_VERSION=$(get_latest_version)
+      BUILDER_VERSION=$(get_builder_latest_version)
       # Create the binary
       go install go.opentelemetry.io/collector/cmd/builder@${BUILDER_VERSION}
       /root/go/bin/builder --config="${CRAFT_PART_BUILD}/manifest.yaml"

--- a/0.123.1/rockcraft.yaml
+++ b/0.123.1/rockcraft.yaml
@@ -17,21 +17,28 @@ services:
     command: "/usr/bin/otelcol [ --config /etc/otelcol/config.yaml ]"
 run-user: _daemon_
 parts:
-  opentelemetry-collector:
-    plugin: dump
-    source: .
+  ocb:
+    plugin: go
+    source: "https://github.com/open-telemetry/opentelemetry-collector.git"
+    source-type: "git"
+    source-tag: "v0.123.0"
+    source-depth: 1
+    source-subdir: "cmd/builder"
     build-snaps:
-      - yq/v4/stable
       - go/1.23/stable
-    build-packages:
-      - git
     build-environment:
       - CGO_ENABLED: "0"
       - GOOS: linux
+    stage:
+      - bin/builder
+  opentelemetry-collector:
+    after:
+      - ocb
+    plugin: dump
+    source: .
     override-build: |
       # Create the binary
-      go install go.opentelemetry.io/collector/cmd/builder@v0.123.0
-      /root/go/bin/builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
+      builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol ${CRAFT_PART_INSTALL}/opt/otelcol/otelcol
     organize:
       opt/otelcol/otelcol: usr/bin/otelcol


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes #23 and at the same time closes PR #22 (since it is based on it)

## Solution

We have divided the `parts` into `ocb` (builder) and `opentelemetry-collector` since both may have different versions


```yaml
version: "0.123.1"
base: ubuntu@24.04
license: Apache-2.0
platforms:
  amd64:
services:
  otelcol:
    override: replace
    summary: "Entry point for opentelemetry-collector oci-image"
    startup: enabled
    command: "/usr/bin/otelcol [ --config /etc/otelcol/config.yaml ]"
run-user: _daemon_
parts:
  ocb:
    plugin: go
    source: "https://github.com/open-telemetry/opentelemetry-collector.git"
    source-type: "git"
    source-tag: "v0.123.0"
    source-depth: 1
    source-subdir: "cmd/builder"
    build-snaps:
      - go/1.23/stable
    build-environment:
      - CGO_ENABLED: "0"
      - GOOS: linux
    stage:
      - bin/builder
    prime:
      - "-*"
  opentelemetry-collector:
    after:
      - ocb
    plugin: dump
    source: .
    override-build: |
      # Create the binary
      builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
      install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol ${CRAFT_PART_INSTALL}/opt/otelcol/otelcol
    organize:
      opt/otelcol/otelcol: usr/bin/otelcol
    permissions:
      # _daemon_ user has UID/GID = 584792
      # Ref: https://documentation.ubuntu.com/rockcraft/en/stable/reference/rockcraft.yaml/#run-user
      - path: usr/bin/otelcol
        owner: 584792
        group: 584792
        mode: "500"
```

## Alternative solution
<!-- A summary of the solution addressing the above issue -->

If we want to automatically get the last `ocb` version we can follow this approach.


```diff
modified   0.123.1/rockcraft.yaml
@@ -23,13 +23,21 @@ parts:
     build-snaps:
       - yq/v4/stable
       - go/1.23/stable
+    build-packages:
+      - git
     build-environment:
       - CGO_ENABLED: "0"
       - GOOS: linux
     override-build: |
-      VERSION=v$(yq '.version' rockcraft.yaml)
+      get_builder_latest_version() {
+        set +o pipefail
+        local version=$(git ls-remote --tags --sort=-v:refname https://github.com/open-telemetry/opentelemetry-collector/ | head -n 1 | awk '{print $2}' | sed -E 's|refs/tags/||;s|\^\{\}||')
+        set -o pipefail
+        echo "$version"
+      }
+      BUILDER_VERSION=$(get_builder_latest_version)
       # Create the binary
-      go install go.opentelemetry.io/collector/cmd/builder@$VERSION
+      go install go.opentelemetry.io/collector/cmd/builder@${BUILDER_VERSION}
       /root/go/bin/builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol ${CRAFT_PART_INSTALL}/opt/otelcol/otelcol
     organize:
@@ -41,7 +49,6 @@ parts:
         owner: 584792
         group: 584792
         mode: "500"
-    source-tag: v0.123.1
   default-config:
     plugin: dump
     source: .
```

We use `set +o pipefail` and `set -o pipefail` in order to avoid error `141`:

```
2025-04-07 23:46:23.204 Executing PosixPath('/tmp/tmprvlvvyed/scriptlet.sh')
2025-04-07 23:46:23.207 :: ++ git ls-remote --tags --sort=-v:refname https://github.com/open-telemetry/opentelemetry-collector/
2025-04-07 23:46:23.207 :: ++ head -n 1
2025-04-07 23:46:23.207 :: ++ awk '{print $2}'
2025-04-07 23:46:23.207 :: ++ sed -E 's|refs/tags/||;s|\^\{\}||'
2025-04-07 23:46:23.840 :: + BUILDER_VERSION=v0.123.0
2025-04-07 23:46:23.841 'override-build' in part 'opentelemetry-collector' failed with code 141.
```

Error code `141` generally indicates that a process received the `SIGPIPE` signal, which happens when a command in a pipeline (`|`) tries to write to a command that has already finished.