### PR TITLE
feat: add basicauthextension

### DIFF
--- a/0.123.1/manifest-additions.yaml
+++ b/0.123.1/manifest-additions.yaml
@@ -1,3 +1,6 @@
+extensions:
+  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
+
 receivers:
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
 


### PR DESCRIPTION
## Issue

When integrating **opentelemetry-collector-k8s** with **grafana-cloud-integrator**, I noticed that basic auth is not supported out-of-the-box. We need this for feature parity with **grafana-agent-k8s**.

## Solution

There is an extension which handles basic auth: [`basicauthextension`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/basicauthextension/README.md). This PR adds that extension to the rock.