### PR TITLE
feat: add transform processor

### DIFF
--- a/0.127.0/manifest-additions.yaml
+++ b/0.127.0/manifest-additions.yaml
@@ -7,6 +7,7 @@ receivers:
 processors:
   - github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
   - github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
+  - github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
 
 exporters:
   - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter

--- a/0.127.0/manifest.yaml
+++ b/0.127.0/manifest.yaml
@@ -24,6 +24,7 @@ exporters:
 processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.127.0
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.127.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.127.0

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ set export # Just variables are exported to environment variables
 rock_name := `echo ${PWD##*/} | sed 's/-rock//'`
 # To find the latest version, get the "last" folder that starts with a number
 latest_version := `find . -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -n1 | sed 's@./@@'`
+manifest_path := latest_version + "/manifest.yaml"
 
 [private]
 default:
@@ -33,6 +34,17 @@ clean version=latest_version:
 # Run a rock and open a shell into it with `kgoss`
 run version=latest_version: (push-to-registry version)
   kgoss edit -i localhost:32000/${rock_name}-dev:${version}
+
+# Make sure you've run ocb-manifest
+lint-manifest version=latest_version: (ocb-manifest version "/tmp/manifest.yaml")
+  #!/usr/bin/env bash
+  if ! diff -q "${version}/manifest.yaml" "/tmp/manifest.yaml"; then
+    echo "The manifest.yaml for ${version} has not been updated."
+    echo "Please run: just ocb-manifest ${version}"
+    exit  1
+  else
+    echo "The manifest.yaml for ${version} is correct!"
+  fi
 
 # Run all the tests
 [group("test")]
@@ -75,13 +87,12 @@ test-integration version=latest_version: (push-to-registry version)
   done
 
 # Generate the OCB manifest
-ocb-manifest version=latest_version:
+ocb-manifest version=latest_version manifest=(version + "/manifest.yaml"):
   #!/usr/bin/env bash
   BASE_URL="https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases\
   /refs/tags/v${version}/distributions/"
-  cd "${version}"
-  wget "${BASE_URL}/otelcol/manifest.yaml" -O "manifest-core.yaml" --quiet
-  wget "${BASE_URL}/otelcol-contrib/manifest.yaml" -O "manifest-contrib.yaml" --quiet
+  wget "${BASE_URL}/otelcol/manifest.yaml" -O "${version}/manifest-core.yaml" --quiet
+  wget "${BASE_URL}/otelcol-contrib/manifest.yaml" -O "${version}/manifest-contrib.yaml" --quiet
   yq eval-all '
     select(fileIndex == 0) as $core |
     select(fileIndex == 1) as $contrib |
@@ -89,6 +100,7 @@ ocb-manifest version=latest_version:
     $contrib |
     with_entries(.value |= map(select(.gomod | contains($additions.*.[])))) as $filtered |
     $filtered *+ $core
-  ' manifest-core.yaml manifest-contrib.yaml manifest-additions.yaml | tee manifest.yaml >/dev/null
-  echo "OCB manifest generated in ${version}/manifest.yaml"
+  ' ${version}/manifest-core.yaml ${version}/manifest-contrib.yaml ${version}/manifest-additions.yaml \
+    | tee ${manifest} >/dev/null
+  echo "OCB manifest generated in ${manifest}"
 

--- a/justfile
+++ b/justfile
@@ -48,7 +48,8 @@ lint-manifest version=latest_version: (ocb-manifest version "/tmp/manifest.yaml"
 
 # Run all the tests
 [group("test")]
-test version=latest_version: (push-to-registry version) \
+test version=latest_version: (lint-manifest version) \
+  (push-to-registry version) \
   (test-isolation version) \
   (test-integration version)
 


### PR DESCRIPTION
## Issue
We need the `transform` processor in otel collector.

## Solution
Add the processor to the manifest for 0.127.0.

## Testing Instructions
The `justfile` has been modified to add a linting step to the ocb manifest. Oftentimes, we forget that after adding a plugin to the `manifest-additions.yaml` file, we also need to run `just ocb-manifest <version>`. This linting step makes sure we don't forget, and it's executed as part of the tests.
