### PR TITLE
(fix) use opentelemetry-collector to get the version

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     with:
       rock-name: opentelemetry-collector
-      source-repo: open-telemetry/opentelemetry-collector-releases
+      source-repo: open-telemetry/opentelemetry-collector
       check-go: true
       update-script: |
         cd "$(dirname "$rockcraft_yaml")"  # cd into the rock folder


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

[We have a failing CI](https://github.com/canonical/opentelemetry-collector-rock/actions/runs/16038692338/job/45943165870)


```
Failed to pull source: command \['/snap/rockcraft/3367/libexec/rockcraft/craft.git', 'clone', '--recursive', '--branch', 'v0.129.1', '--depth', '1', '[https://github.com/open-telemetry/opentelemetry-collector.git](https://github.com/open-telemetry/opentelemetry-collector.git)', '/root/parts/ocb/src'\] exited with code 128.
```

As far as I understand, this error is happening because we are trying to build `opentelemetry-collector` getting the version from [`opentelemetry-collector-releases`](https://github.com/open-telemetry/opentelemetry-collector-releases) tag. But there is no sync between `otelcol` branches and `otelcol-releases` tags. In fact, [they say](https://github.com/open-telemetry/opentelemetry-collector-releases?tab=readme-ov-file#opentelemetry-collector-distributions):


## OpenTelemetry Collector distributions

> :warning: **Important note:** Git tags in this repository may change at any time to fix any issues found during a release. They are only meant to trigger Github releases and should not be relied upon.

# Solution

Now we get the version from `opentelemetry-collector` repo instead of `opentelemetry-collector-releases`
