### PR TITLE
feat: add standalone rock usage documentation

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,10 +60,10 @@ test-isolation version=latest_version: (push-to-registry version)
 
 # Test the rock integration with other workloads
 [group("test")]
-test-integration version=latest_version: (push-to-registry version)
+test-integration version=latest_version test_name="": (push-to-registry version)
   #!/usr/bin/env bash
   # For all the subfolder in tests/
-  for test_folder in $(find tests -mindepth 1 -maxdepth 1 -type d | sed 's@tests/@@'); do
+  for test_folder in $(find tests -mindepth 1 -maxdepth 1 -type d | sed 's@tests/@@' | grep -i "$test_name"); do
     # Create a namespace for the tests to run in
     namespace="test-${rock_name}-rock-${test_folder//_/-}"
     echo "+ Preparing the testing environment"

--- a/tests/node_exporter/goss.yaml
+++ b/tests/node_exporter/goss.yaml
@@ -1,0 +1,31 @@
+command:
+  remote-write:
+    exit-status: 0
+    exec: |
+      echo "Namespace: {{.Env.NAMESPACE}}"
+      # Get Prometheus pod
+      PROMETHEUS_IP="$(kubectl get pod -n {{.Env.NAMESPACE}} -l app="prometheus" \
+        -o jsonpath='{.items[*].status.podIP}')"
+      if [ -z "$PROMETHEUS_IP" ]; then
+        echo "Prometheus pod IP not found, maybe the pod isn't ready yet"
+        exit 1
+      fi
+      echo "Prometheus IP: $PROMETHEUS_IP"
+      LABEL_NAME="testlabel"
+      LABEL_VALUE="testvalue"
+      # Check there is a LABEL_NAME label with value LABEL_VALUE
+      LABELS="$(curl -s "${PROMETHEUS_IP}:9090/api/v1/label/${LABEL_NAME}/values")"
+      echo "Prometheus '${LABEL_NAME}' label values: $LABELS"
+      if ! echo "$LABELS" | grep -q "${LABEL_VALUE}"; then
+        echo "'${LABEL_NAME}=${LABEL_VALUE}' label not found"
+        exit 2
+      fi
+      LABEL_NAME="source"
+      LABEL_VALUE="node-exporter"
+      # Check specifically for the label 'source: node-exporter'
+      LABELS="$(curl -s "${PROMETHEUS_IP}:9090/api/v1/label/${LABEL_NAME}/values")"
+      echo "Prometheus '${LABEL_NAME}' label values: $LABELS"
+      if ! echo "$LABELS" | grep -q "${LABEL_VALUE}"; then
+        echo "'${LABEL_NAME}=${LABEL_VALUE}' label not found"
+        exit 2
+      fi

--- a/tests/node_exporter/node-exporter.yaml
+++ b/tests/node_exporter/node-exporter.yaml
@@ -1,0 +1,45 @@
+--- # Node Exporter Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      hostPID: true
+      containers:
+        - name: node-exporter
+          image: ubuntu/node-exporter:1.9-24.04
+          args:
+            - '--args'
+            - '--path.rootfs=/host'
+          ports:
+            - containerPort: 9100 # Default port for Node Exporter
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+              readOnly: true
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /
+--- # Node Exporter Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9100
+      name: metrics
+  selector:
+    app: node-exporter
+

--- a/tests/node_exporter/otel-collector.yaml
+++ b/tests/node_exporter/otel-collector.yaml
@@ -1,0 +1,94 @@
+--- # OpenTelemetry Collector config
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otelcol-config
+data:
+  config.yaml: |
+    # otel config goes here
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: 'self-monitoring'
+            scrape_interval: 10s
+            static_configs:
+            - targets: ['0.0.0.0:8888']
+              labels:
+                testlabel: testvalue
+                source: otelcol
+          - job_name: 'node-exporter'
+            scrape_interval: 10s
+            static_configs:
+            - targets: ['http://node-exporter.test-opentelemetry-collector-rock-node-exporter.svc.cluster.local:9100/metrics']
+              labels:
+                testlabel: testvalue
+                source: node-exporter
+
+    exporters:
+      debug:
+        verbosity: detailed
+      prometheus:
+        endpoint: ":8889"
+      prometheusremotewrite:
+        endpoint: "http://prometheus.test-opentelemetry-collector-rock-prometheus-integration.svc.cluster.local:9090/api/v1/write"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug, prometheus, prometheusremotewrite]
+      extensions: [health_check]
+      telemetry:
+        metrics:
+          level: basic # Set to 'normal' or 'detailed' for more metrics
+--- # OpenTelemetry Collector deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-collector-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opentelemetry-collector-dev
+  template:
+    metadata:
+      labels:
+        app: opentelemetry-collector-dev
+    spec:
+      containers:
+        - name: opentelemetry-collector-dev
+          image: localhost:32000/opentelemetry-collector-dev:latest
+          ports:
+            - containerPort: 55678 # workload ports, add more if needed
+            - containerPort: 13133 # health endpoint
+            - containerPort: 8888 # metrics
+          volumeMounts:
+            - name: otelcol-config-volume
+              mountPath: /etc/otelcol/config.yaml # Change this to the desired mount path
+              subPath: config.yaml  # This specifies the file name in the ConfigMap
+      volumes:
+        - name: otelcol-config-volume
+          configMap:
+            name: otelcol-config
+--- # OpenTelemetry Collector Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: opentelemetry-collector-dev
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8888
+      name: prometheus-receiver
+    - port: 8889
+      name: metrics-endpoint
+    - port: 13133
+      name: health-check
+  selector:
+    app: opentelemetry-collector-dev

--- a/tests/node_exporter/prometheus.yaml
+++ b/tests/node_exporter/prometheus.yaml
@@ -1,0 +1,55 @@
+--- # Prometheus config
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    # prometheus config goes here
+    global:
+      scrape_interval: 15s  # Default scrape interval
+
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090']  # Adjust as necessary
+--- # Prometheus Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: ubuntu/prometheus:2.53-24.04
+          args: ["--args", "prometheus", "--web.enable-remote-write-receiver"]
+          ports:
+            - containerPort: 9090 # Prometheus port
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-config
+--- # Prometheus Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+  selector:
+    app: prometheus


### PR DESCRIPTION
## Issue
Add docs to the README on how to use and deploy the rock on its own, with node exporter and Prometheus; references a new integration test that deploys exactly that.