### PR TITLE
feat: include syslogexporter to 0.130 and 0.130.1 so we can build this version's snap

### DIFF
--- a/0.130.0/manifest-additions.yaml
+++ b/0.130.0/manifest-additions.yaml
@@ -13,3 +13,4 @@ processors:
 
 exporters:
   - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
+  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter

--- a/0.130.1/manifest-additions.yaml
+++ b/0.130.1/manifest-additions.yaml
@@ -13,3 +13,4 @@ processors:
 
 exporters:
   - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
+  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR includes `syslogexporter` to `0.130.0` so based on this the opentelemetry-collector snap can be built and installed by opentelemetry-collector charm
